### PR TITLE
Update index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,7 +88,7 @@ This approach has many benefits:</p>
 <ul>
 <li>Vendor perl usually serves its own purposes, and it might be a bad idea to mess it up too much.</li>
 <li>Especially PITA when trying to upgrade system perl.</li>
-<li>Some vendors <a href="http://perlnews.org/2011/04/dealing-with-xcode-4-and-cpan-breakage/">introduced their own perl bugs</a>, <a href="http://www.theregister.co.uk/2009/02/16/apple_update_perl_breakage/">twice</a>!</li>
+<li>Some vendors <a href="http://web.archive.org/web/20110809020042/http://perlnews.org/2011/04/dealing-with-xcode-4-and-cpan-breakage/">introduced their own perl bugs</a>, <a href="http://www.theregister.co.uk/2009/02/16/apple_update_perl_breakage/">twice</a>!</li>
 </ul></li>
 <li>Hacking perl internals.</li>
 <li>Just to keep up with fashion.</li>


### PR DESCRIPTION
http://perlnews.org/2011/04/dealing-with-xcode-4-and-cpan-breakage/ is now a 404 - link to the wayback machine.