### PR TITLE
Align example for clone-modules to perldoc

### DIFF
--- a/public/Reinstall-All-Modules-On-New-Perl.html
+++ b/public/Reinstall-All-Modules-On-New-Perl.html
@@ -53,10 +53,10 @@ perlbrew list-modules
 
 <p>For instance:</p>
 
-<pre><code>perlbrew clone-modules 5.27.7 5.26.1
+<pre><code>perlbrew clone-modules 5.26.1 5.27.7
 </code></pre>
 
-<p>will <em>clone</em> all modules from instance <code>5.27.7</code> to instance <code>5.26.1</code>.</p>
+<p>will <em>clone</em> all modules from instance <code>5.26.1</code> to instance <code>5.27.7</code>.</p>
 
 <p>For <code>perlbrew</code> version prior to <em>0.81</em> or in case the <code>clone-modules</code>
 does not what you need, the following one liner can pipe all modules from one


### PR DESCRIPTION
I made sure the syntax is described correctly and used the opposite operation because that is from the perldoc for `perlbrew` and more typical (clone from older to newer version).